### PR TITLE
Handle signin 404 error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -19,6 +19,14 @@ app.use((0, cors_1.default)({
 }));
 app.use(express_1.default.json({ limit: '50mb' }));
 app.use(express_1.default.urlencoded({ extended: true }));
+// Add root-level signin route for frontend compatibility
+app.get('/signin', (req, res) => {
+    res.json({
+        message: 'Please use POST /api/auth/login to authenticate',
+        loginEndpoint: '/api/auth/login',
+        registerEndpoint: '/api/auth/register'
+    });
+});
 app.use('/api/auth', auth_1.default);
 app.use('/api/tasks', tasks_1.default);
 app.use('/api/user', user_1.default);

--- a/dist/routes/auth.js
+++ b/dist/routes/auth.js
@@ -4,6 +4,14 @@ const express_1 = require("express");
 const authController_1 = require("../controllers/auth/authController");
 const auth_1 = require("../middlewares/auth");
 const router = (0, express_1.Router)();
+// Add GET route for signin page requests
+router.get('/signin', (req, res) => {
+    res.json({
+        message: 'Signin page',
+        loginEndpoint: '/api/auth/login',
+        registerEndpoint: '/api/auth/register'
+    });
+});
 router.post('/register', authController_1.register);
 router.post('/login', authController_1.login);
 router.post('/logout', authController_1.logout);

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,15 @@ app.use(cors({
 app.use(express.json({ limit: '50mb' })); 
 app.use(express.urlencoded({ extended: true }));
 
+// Add root-level signin route for frontend compatibility
+app.get('/signin', (req, res) => {
+  res.json({ 
+    message: 'Please use POST /api/auth/login to authenticate',
+    loginEndpoint: '/api/auth/login',
+    registerEndpoint: '/api/auth/register'
+  });
+});
+
 app.use('/api/auth', authRoutes);
 app.use('/api/tasks', taskRoutes);
 app.use('/api/user', userRoutes);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "server",
+  "name": "workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/routes/auth.ts
+++ b/routes/auth.ts
@@ -4,6 +4,15 @@ import { authenticateToken } from '../middlewares/auth';
 
 const router = Router();
 
+// Add GET route for signin page requests
+router.get('/signin', (req, res) => {
+  res.json({ 
+    message: 'Signin page', 
+    loginEndpoint: '/api/auth/login',
+    registerEndpoint: '/api/auth/register'
+  });
+});
+
 router.post('/register', register);
 router.post('/login', login);
 router.post('/logout', logout);


### PR DESCRIPTION
Add GET `/signin` routes to resolve 404 errors from frontend client requests.

The frontend client was making a GET request to `/signin`, but the backend server only had POST authentication routes under `/api/auth` (e.g., `/api/auth/login`). These new GET routes provide a placeholder response for the frontend's expected `/signin` endpoint.

---

[Open in Web](https://cursor.com/agents?id=bc-25d5ae5b-b31b-47ce-ab2f-b570e936a3de) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-25d5ae5b-b31b-47ce-ab2f-b570e936a3de) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)